### PR TITLE
Add plugin.video.dvtv

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -168,3 +168,6 @@
 [submodule "plugin.video.stream-cinema"]
 	path = plugin.video.stream-cinema
 	url = https://github.com/bbaronSVK/plugin.video.stream-cinema.git
+[submodule "plugin.video.dvtv"]
+	path = plugin.video.dvtv
+	url = https://github.com/lipelix/plugin.video.dvtv

--- a/addons.py
+++ b/addons.py
@@ -14,6 +14,7 @@ __ADDONS__ = [
     "plugin.video.hejbejse.tv",
     "plugin.video.idnestv",
     "plugin.video.ivysilani",
+    "plugin.video.dvtv",
     "plugin.video.jaksetodela.cz",
     "plugin.video.joj.sk",
     "plugin.video.markiza.sk",


### PR DESCRIPTION
Plugin pro sledování `dvtv.cz`. Předchozí má ukončený vývoj `https://github.com/kodi-czsk/plugin.video.dmd-czech.dvtv` a `https://github.com/kodi-czsk/plugin.video.dmd-czech.aktualne` je nefunkční.